### PR TITLE
Add react

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -94,4 +94,8 @@ function main(){
 	})
 }
 
-$(document).ready(main);
+//listen for DOM ready (doesn't work with TL partial load)
+// $(document).ready(main); 
+
+//listen for turbolink load
+$( document ).on('turbolinks:load', function(){ main() });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,6 @@
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
     <%= csrf_meta_tags %>
-    <!-- webpacker JSpack -->
-    <%= javascript_pack_tag 'application' %>
     <!-- makes css respsonsive with mobile -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Cherry+Cream+Soda" />

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,11 +3,13 @@
   <head>
     <title>MusicServer</title>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-    <%= csrf_meta_tags %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
+    <%= csrf_meta_tags %>
+    <!-- webpacker JSpack -->
+    <%= javascript_pack_tag 'application' %>
     <!-- makes css respsonsive with mobile -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Cherry+Cream+Soda" />
   </head>
   <body>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
 <br/>
 <br/>
 <h2>Playlist:</h2>
-<ul>
+<ul class='songList'>
 	<% @user.playlists.each do |playlist| %>
 		<li><%= link_to playlist.name, playlist_path(playlist) %></li>
 	<% end %>


### PR DESCRIPTION
jquery load at DOM ready and turbolink creates a partial page load which doesn't initiates a DOM.ready event on page navigation. 